### PR TITLE
Add cross-platform machine ID library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go vet ./...
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Package `machineid` provides cross-platform generation of a stable machine
 identifier for Go applications.
 
-The identifier is built from two components:
+The identifier is built from three pieces of information:
 
 - **SMBIOS hardware UUID** – a value provided by the system firmware. Hypervisors
   typically generate a new SMBIOS UUID for cloned virtual machines, ensuring that
@@ -11,10 +11,12 @@ The identifier is built from two components:
 - **Operating system installation ID** – the OS's own identifier when available.
   Examples include `/etc/machine-id` on Linux and the `MachineGuid` registry value
   on Windows. This acts as an additional safeguard and fallback.
+- **Operating system name** – included to distinguish IDs when a machine is
+  re-imaged with a different OS.
 
-The final ID is the SHA-256 hash of the two components concatenated together. No
-MAC addresses or other volatile values are used, making the result stable even on
-modern macOS versions that randomise network interfaces on each reboot.
+The final ID is the SHA-256 hash of the string `os:<goos>|bios:<uuid>|inst:<id>`.
+No MAC addresses or other volatile values are used, making the result stable even
+on modern macOS versions that randomise network interfaces on each reboot.
 
 ## Usage
 
@@ -44,14 +46,24 @@ func main() {
 }
 ```
 
+For troubleshooting, `RawID` exposes the underlying components:
+
+```go
+bios, inst := machineid.RawID()
+fmt.Println("bios:", bios, "install:", inst)
+```
+
 ## Supported platforms
 
-- **Linux** – reads the SMBIOS UUID from `/sys/class/dmi/id/product_uuid` and the
-  installation ID from `/etc/machine-id` (falling back to
-  `/var/lib/dbus/machine-id`).
-- **macOS** – obtains the SMBIOS UUID and serial number from `ioreg`.
-- **Windows** – uses `wmic csproduct get UUID` for the SMBIOS UUID and the
-  `MachineGuid` registry key for the installation ID.
+- **Linux** – reads the SMBIOS UUID from `/sys/class/dmi/id/product_uuid`
+  (falling back to `/sys/devices/virtual/dmi/id/product_uuid`) and the installation
+  ID from `/etc/machine-id` or `/var/lib/dbus/machine-id`.
+- **macOS** – obtains the hardware UUID from `ioreg` (falling back to
+  `system_profiler`) and uses the system serial number as the installation ID,
+  reusing the hardware UUID if unavailable.
+- **Windows** – queries the SMBIOS UUID via PowerShell's CIM interface (with
+  `wmic` fallback) and reads the installation ID from the `MachineGuid` registry
+  value using `reg query`.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# machineid
+
+Package `machineid` provides cross-platform generation of a stable machine
+identifier for Go applications.
+
+The identifier is built from two components:
+
+- **SMBIOS hardware UUID** – a value provided by the system firmware. Hypervisors
+  typically generate a new SMBIOS UUID for cloned virtual machines, ensuring that
+  each clone receives a different identifier.
+- **Operating system installation ID** – the OS's own identifier when available.
+  Examples include `/etc/machine-id` on Linux and the `MachineGuid` registry value
+  on Windows. This acts as an additional safeguard and fallback.
+
+The final ID is the SHA-256 hash of the two components concatenated together. No
+MAC addresses or other volatile values are used, making the result stable even on
+modern macOS versions that randomise network interfaces on each reboot.
+
+## Usage
+
+Install the module:
+
+```bash
+go get github.com/machineid/machineid
+```
+
+Then use it in your code:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/machineid/machineid"
+)
+
+func main() {
+    id, err := machineid.ID()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(id)
+}
+```
+
+## Supported platforms
+
+- **Linux** – reads the SMBIOS UUID from `/sys/class/dmi/id/product_uuid` and the
+  installation ID from `/etc/machine-id` (falling back to
+  `/var/lib/dbus/machine-id`).
+- **macOS** – obtains the SMBIOS UUID and serial number from `ioreg`.
+- **Windows** – uses `wmic csproduct get UUID` for the SMBIOS UUID and the
+  `MachineGuid` registry key for the installation ID.
+
+## Releasing
+
+1. Commit any pending changes and update documentation.
+2. Create a new semantic version tag:
+
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+   Go modules will pick up the latest tag automatically.
+
+## License
+
+This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/machineid/machineid
 
 go 1.21
-
-require golang.org/x/sys v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/machineid/machineid
+
+go 1.21
+
+require golang.org/x/sys v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/id.go
+++ b/id.go
@@ -1,0 +1,22 @@
+package machineid
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// ID returns a hashed identifier for the current machine. It combines the
+// SMBIOS hardware UUID with an operating system installation identifier when
+// available and hashes the result using SHA-256. The identifier is stable for a
+// given machine yet changes when the VM or host is cloned by virtue of the
+// SMBIOS UUID changing.
+func ID() (string, error) {
+	hw, errHW := getSMBIOSUUID()
+	osID, errOS := getInstallationID()
+	if errHW != nil && errOS != nil {
+		return "", fmt.Errorf("cannot obtain identifiers: %v; %v", errHW, errOS)
+	}
+	sum := sha256.Sum256([]byte(hw + "|" + osID))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/id.go
+++ b/id.go
@@ -1,22 +1,47 @@
 package machineid
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
+	"errors"
+	"runtime"
+	"strings"
 )
 
 // ID returns a hashed identifier for the current machine. It combines the
-// SMBIOS hardware UUID with an operating system installation identifier when
-// available and hashes the result using SHA-256. The identifier is stable for a
-// given machine yet changes when the VM or host is cloned by virtue of the
-// SMBIOS UUID changing.
+// operating system name, SMBIOS hardware UUID, and an operating system
+// installation identifier when available. The identifier is stable for a
+// given machine yet changes when the VM or host is cloned.
 func ID() (string, error) {
-	hw, errHW := getSMBIOSUUID()
-	osID, errOS := getInstallationID()
-	if errHW != nil && errOS != nil {
-		return "", fmt.Errorf("cannot obtain identifiers: %v; %v", errHW, errOS)
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	bios, _ := getSMBIOSUUID(ctx)
+	inst, _ := getInstallationID(ctx)
+
+	bios = strings.ToLower(strings.TrimSpace(bios))
+	inst = strings.ToLower(strings.TrimSpace(inst))
+
+	if isZeroUUID(bios) {
+		bios = ""
 	}
-	sum := sha256.Sum256([]byte(hw + "|" + osID))
-	return hex.EncodeToString(sum[:]), nil
+
+	if bios == "" && inst == "" {
+		return "", errors.New("machineid: unable to read BIOS UUID or installation ID")
+	}
+
+	h := sha256.New()
+	h.Write([]byte("os:" + runtime.GOOS + "|bios:" + bios + "|inst:" + inst))
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// RawID returns the unprocessed SMBIOS UUID and installation ID used to
+// build the hashed identifier. It is primarily useful for diagnostics.
+func RawID() (biosUUID, installID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+	bios, _ := getSMBIOSUUID(ctx)
+	inst, _ := getInstallationID(ctx)
+	return strings.TrimSpace(bios), strings.TrimSpace(inst)
 }

--- a/id_test.go
+++ b/id_test.go
@@ -1,0 +1,20 @@
+package machineid
+
+import "testing"
+
+func TestIDStable(t *testing.T) {
+	id1, err := ID()
+	if err != nil {
+		t.Fatalf("ID returned error: %v", err)
+	}
+	id2, err := ID()
+	if err != nil {
+		t.Fatalf("ID returned error: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("expected stable ID, got %q and %q", id1, id2)
+	}
+	if id1 == "" {
+		t.Fatal("ID is empty")
+	}
+}

--- a/id_test.go
+++ b/id_test.go
@@ -18,3 +18,11 @@ func TestIDStable(t *testing.T) {
 		t.Fatal("ID is empty")
 	}
 }
+
+func TestRawIDStable(t *testing.T) {
+	b1, i1 := RawID()
+	b2, i2 := RawID()
+	if b1 != b2 || i1 != i2 {
+		t.Fatalf("expected stable raw IDs, got %q/%q and %q/%q", b1, i1, b2, i2)
+	}
+}

--- a/internal.go
+++ b/internal.go
@@ -1,0 +1,39 @@
+package machineid
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const cmdTimeout = 1500 * time.Millisecond
+
+func run(ctx context.Context, name string, args ...string) string {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+	_ = cmd.Run()
+	return b.String()
+}
+
+var uuidRE = regexp.MustCompile(`(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+func firstUUID(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	m := uuidRE.FindString(s)
+	return strings.ToLower(m)
+}
+
+func isZeroUUID(u string) bool {
+	u = strings.ToLower(strings.TrimSpace(u))
+	zero := "00000000-0000-0000-0000-000000000000"
+	ffff := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	return u == zero || u == ffff
+}

--- a/machineid_darwin.go
+++ b/machineid_darwin.go
@@ -3,22 +3,31 @@
 package machineid
 
 import (
-	"fmt"
-	"os/exec"
+	"context"
+	"errors"
 	"strings"
 )
 
-func getIOPlatformProperty(prop string) (string, error) {
-	out, err := exec.Command("ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
-	if err != nil {
-		return "", err
+func getSMBIOSUUID(ctx context.Context) (string, error) {
+	out := run(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+	if u := firstUUID(out); u != "" {
+		return u, nil
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	out = run(ctx, "system_profiler", "SPHardwareDataType")
+	if u := firstUUID(out); u != "" {
+		return u, nil
+	}
+	return "", errors.New("IOPlatformUUID not found")
+}
+
+func getInstallationID(ctx context.Context) (string, error) {
+	out := run(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "\""+prop+"\"") {
+		if strings.HasPrefix(line, "\"IOPlatformSerialNumber\"") {
 			parts := strings.Split(line, "=")
 			if len(parts) != 2 {
-				continue
+				break
 			}
 			v := strings.Trim(parts[1], " \"")
 			if v != "" {
@@ -26,16 +35,6 @@ func getIOPlatformProperty(prop string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("%s not found", prop)
-}
-
-func getSMBIOSUUID() (string, error) {
-	return getIOPlatformProperty("IOPlatformUUID")
-}
-
-func getInstallationID() (string, error) {
-	// macOS does not expose an explicit installation ID. We approximate this
-	// using the serial number from the IORegistry, which changes on hardware
-	// replacement and differs across VM clones.
-	return getIOPlatformProperty("IOPlatformSerialNumber")
+	// Fallback: reuse hardware UUID if serial number unavailable
+	return getSMBIOSUUID(ctx)
 }

--- a/machineid_darwin.go
+++ b/machineid_darwin.go
@@ -1,0 +1,41 @@
+//go:build darwin
+
+package machineid
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func getIOPlatformProperty(prop string) (string, error) {
+	out, err := exec.Command("ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\""+prop+"\"") {
+			parts := strings.Split(line, "=")
+			if len(parts) != 2 {
+				continue
+			}
+			v := strings.Trim(parts[1], " \"")
+			if v != "" {
+				return strings.ToLower(v), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("%s not found", prop)
+}
+
+func getSMBIOSUUID() (string, error) {
+	return getIOPlatformProperty("IOPlatformUUID")
+}
+
+func getInstallationID() (string, error) {
+	// macOS does not expose an explicit installation ID. We approximate this
+	// using the serial number from the IORegistry, which changes on hardware
+	// replacement and differs across VM clones.
+	return getIOPlatformProperty("IOPlatformSerialNumber")
+}

--- a/machineid_linux.go
+++ b/machineid_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package machineid
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+func getSMBIOSUUID() (string, error) {
+	data, err := os.ReadFile("/sys/class/dmi/id/product_uuid")
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" || strings.EqualFold(id, "unknown") {
+		return "", errors.New("product uuid not available")
+	}
+	return strings.ToLower(id), nil
+}
+
+func getInstallationID() (string, error) {
+	paths := []string{"/etc/machine-id", "/var/lib/dbus/machine-id"}
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		id := strings.TrimSpace(string(data))
+		if id != "" {
+			return strings.ToLower(id), nil
+		}
+	}
+	return "", errors.New("machine-id not found")
+}

--- a/machineid_linux.go
+++ b/machineid_linux.go
@@ -3,24 +3,32 @@
 package machineid
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
 )
 
-func getSMBIOSUUID() (string, error) {
-	data, err := os.ReadFile("/sys/class/dmi/id/product_uuid")
-	if err != nil {
-		return "", err
+func getSMBIOSUUID(_ context.Context) (string, error) {
+	paths := []string{
+		"/sys/class/dmi/id/product_uuid",
+		"/sys/devices/virtual/dmi/id/product_uuid",
 	}
-	id := strings.TrimSpace(string(data))
-	if id == "" || strings.EqualFold(id, "unknown") {
-		return "", errors.New("product uuid not available")
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		id := strings.TrimSpace(string(data))
+		if id == "" || strings.EqualFold(id, "unknown") {
+			continue
+		}
+		return strings.ToLower(id), nil
 	}
-	return strings.ToLower(id), nil
+	return "", errors.New("product uuid not available")
 }
 
-func getInstallationID() (string, error) {
+func getInstallationID(_ context.Context) (string, error) {
 	paths := []string{"/etc/machine-id", "/var/lib/dbus/machine-id"}
 	for _, p := range paths {
 		data, err := os.ReadFile(p)

--- a/machineid_other.go
+++ b/machineid_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package machineid
+
+import "errors"
+
+func getSMBIOSUUID() (string, error) {
+	return "", errors.New("unsupported platform")
+}
+
+func getInstallationID() (string, error) {
+	return "", errors.New("unsupported platform")
+}

--- a/machineid_other.go
+++ b/machineid_other.go
@@ -2,12 +2,15 @@
 
 package machineid
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
-func getSMBIOSUUID() (string, error) {
+func getSMBIOSUUID(context.Context) (string, error) {
 	return "", errors.New("unsupported platform")
 }
 
-func getInstallationID() (string, error) {
+func getInstallationID(context.Context) (string, error) {
 	return "", errors.New("unsupported platform")
 }

--- a/machineid_windows.go
+++ b/machineid_windows.go
@@ -3,41 +3,33 @@
 package machineid
 
 import (
+	"context"
 	"errors"
-	"os/exec"
 	"strings"
-
-	"golang.org/x/sys/windows/registry"
 )
 
-func getSMBIOSUUID() (string, error) {
-	out, err := exec.Command("wmic", "csproduct", "get", "UUID").CombinedOutput()
-	if err != nil {
-		return "", err
+func getSMBIOSUUID(ctx context.Context) (string, error) {
+	out := run(ctx, "powershell", "-NoProfile", "-Command", "(Get-CimInstance Win32_ComputerSystemProduct).UUID")
+	if u := firstUUID(out); u != "" {
+		return u, nil
 	}
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.EqualFold(line, "uuid") {
-			continue
-		}
-		return strings.ToLower(line), nil
+	out = run(ctx, "wmic", "csproduct", "get", "uuid")
+	if u := firstUUID(out); u != "" {
+		return u, nil
 	}
-	return "", errors.New("wmic returned no uuid")
+	return "", errors.New("no uuid found")
 }
 
-func getInstallationID() (string, error) {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Cryptography`, registry.QUERY_VALUE)
-	if err != nil {
-		return "", err
+func getInstallationID(ctx context.Context) (string, error) {
+	out := run(ctx, "cmd", "/C", `reg query HKLM\SOFTWARE\Microsoft\Cryptography /v MachineGuid`)
+	lines := strings.Split(out, "\n")
+	for _, ln := range lines {
+		if strings.Contains(ln, "MachineGuid") {
+			fields := strings.Fields(ln)
+			if len(fields) > 0 {
+				return strings.ToLower(fields[len(fields)-1]), nil
+			}
+		}
 	}
-	defer k.Close()
-	s, _, err := k.GetStringValue("MachineGuid")
-	if err != nil {
-		return "", err
-	}
-	if s == "" {
-		return "", errors.New("machine guid empty")
-	}
-	return strings.ToLower(s), nil
+	return "", errors.New("MachineGuid not found")
 }

--- a/machineid_windows.go
+++ b/machineid_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package machineid
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func getSMBIOSUUID() (string, error) {
+	out, err := exec.Command("wmic", "csproduct", "get", "UUID").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.EqualFold(line, "uuid") {
+			continue
+		}
+		return strings.ToLower(line), nil
+	}
+	return "", errors.New("wmic returned no uuid")
+}
+
+func getInstallationID() (string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Cryptography`, registry.QUERY_VALUE)
+	if err != nil {
+		return "", err
+	}
+	defer k.Close()
+	s, _, err := k.GetStringValue("MachineGuid")
+	if err != nil {
+		return "", err
+	}
+	if s == "" {
+		return "", errors.New("machine guid empty")
+	}
+	return strings.ToLower(s), nil
+}


### PR DESCRIPTION
## Summary
- Implement `ID()` to hash SMBIOS and OS installation identifiers
- Add OS-specific UUID retrieval for Linux, macOS, and Windows
- Document usage, release steps, and platform support
- Run CI in GitHub Actions for vet and test

## Testing
- `go vet -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68abad62e440832e9863dae3fda990bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a cross-platform machine identifier API that returns a stable, deterministic ID on Linux, macOS, and Windows.

* **Documentation**
  - Added README with usage examples, platform behavior, release steps, and MIT license.

* **Tests**
  - Added tests to verify ID and raw components are stable and non-empty.

* **Chores**
  - CI workflow to run vet and tests on push/PR; initialized Go module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->