### PR TITLE
Add macOS support, introduce error handling, and update module path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -13,5 +13,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+          cache: true
       - run: go vet ./...
       - run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ fmt.Println("bios:", bios, "install:", inst)
 
 ## License
 
-This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE).
+This project is licensed under the terms of the Apache License 2.0. See [LICENSE](LICENSE).

--- a/cmd/print/main.go
+++ b/cmd/print/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/think0rcode/machineid"
+)
+
+func main() {
+	// Get raw components
+	bios, inst := machineid.RawID()
+	fmt.Printf("bios=%s\ninst=%s\n", bios, inst)
+
+	// Get hashed machine ID
+	id, err := machineid.ID()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("hashed=%s\n", id)
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+// errors.go
+package machineid
+
+import "errors"
+
+// ErrUnsupported indicates the current platform is not supported
+// by the SMBIOS/installation ID backends.
+var ErrUnsupported = errors.New("machineid: unsupported platform")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/machineid/machineid
+module github.com/think0rcode/machineid
 
 go 1.21

--- a/id.go
+++ b/id.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 )
@@ -17,8 +18,8 @@ func ID() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
 
-	bios, _ := getSMBIOSUUID(ctx)
-	inst, _ := getInstallationID(ctx)
+	bios, biosErr := getSMBIOSUUID(ctx)
+	inst, instErr := getInstallationID(ctx)
 
 	bios = strings.ToLower(strings.TrimSpace(bios))
 	inst = strings.ToLower(strings.TrimSpace(inst))
@@ -28,6 +29,26 @@ func ID() (string, error) {
 	}
 
 	if bios == "" && inst == "" {
+		return "", errors.New("machineid: unable to read BIOS UUID or installation ID")
+	}
+
+	if bios == "" && inst == "" {
+		// If both backends are unsupported, surface a more specific error
+		if biosErr != nil && instErr != nil &&
+			strings.Contains(biosErr.Error(), "unsupported platform") &&
+			strings.Contains(instErr.Error(), "unsupported platform") {
+			return "", errors.New("machineid: unsupported platform")
+		}
+
+		// Otherwise, return a combined error to aid debugging
+		if biosErr != nil && instErr != nil {
+			return "", fmt.Errorf("machineid: unable to read BIOS UUID (%w) or installation ID (%w)", biosErr, instErr)
+		} else if biosErr != nil {
+			return "", fmt.Errorf("machineid: unable to read BIOS UUID (%w), installation ID empty", biosErr)
+		} else if instErr != nil {
+			return "", fmt.Errorf("machineid: unable to read installation ID (%w), BIOS UUID empty", instErr)
+		}
+
 		return "", errors.New("machineid: unable to read BIOS UUID or installation ID")
 	}
 

--- a/internal.go
+++ b/internal.go
@@ -16,7 +16,9 @@ func run(ctx context.Context, name string, args ...string) string {
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	cmd.Stderr = &b
-	_ = cmd.Run()
+	if cmd.Run() != nil {
+		return ""
+	}
 	return b.String()
 }
 

--- a/machineid_darwin.go
+++ b/machineid_darwin.go
@@ -36,5 +36,10 @@ func getInstallationID(ctx context.Context) (string, error) {
 		}
 	}
 	// Fallback: reuse hardware UUID if serial number unavailable
-	return getSMBIOSUUID(ctx)
+	uuid, err := getSMBIOSUUID(ctx)
+	if err != nil {
+		return "", errors.New("neither serial number nor hardware UUID found")
+	}
+	return uuid, nil
+
 }

--- a/machineid_other.go
+++ b/machineid_other.go
@@ -4,13 +4,12 @@ package machineid
 
 import (
 	"context"
-	"errors"
 )
 
 func getSMBIOSUUID(context.Context) (string, error) {
-	return "", errors.New("unsupported platform")
+	return "", ErrUnsupported
 }
 
 func getInstallationID(context.Context) (string, error) {
-	return "", errors.New("unsupported platform")
+	return "", ErrUnsupported
 }

--- a/machineid_windows.go
+++ b/machineid_windows.go
@@ -6,10 +6,13 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 func getSMBIOSUUID(ctx context.Context) (string, error) {
 	out := run(ctx, "powershell", "-NoProfile", "-Command", "(Get-CimInstance Win32_ComputerSystemProduct).UUID")
+
 	if u := firstUUID(out); u != "" {
 		return u, nil
 	}
@@ -21,15 +24,17 @@ func getSMBIOSUUID(ctx context.Context) (string, error) {
 }
 
 func getInstallationID(ctx context.Context) (string, error) {
-	out := run(ctx, "cmd", "/C", `reg query HKLM\SOFTWARE\Microsoft\Cryptography /v MachineGuid`)
-	lines := strings.Split(out, "\n")
-	for _, ln := range lines {
-		if strings.Contains(ln, "MachineGuid") {
-			fields := strings.Fields(ln)
-			if len(fields) > 0 {
-				return strings.ToLower(fields[len(fields)-1]), nil
-			}
-		}
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Cryptography`, registry.QUERY_VALUE|registry.WOW64_64KEY)
+	if err != nil {
+		return "", err
 	}
-	return "", errors.New("MachineGuid not found")
+	defer k.Close()
+	guid, _, err := k.GetStringValue("MachineGuid")
+	if err != nil {
+		return "", errors.New("MachineGuid not found")
+	}
+	if guid == "" {
+		return "", errors.New("machine guid empty")
+	}
+	return strings.ToLower(guid), nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a lightweight CLI to display raw machine identifiers and a hashed ID.

- Bug Fixes
  - More reliable Windows machine ID retrieval via direct registry access.
  - Improved error handling when system commands fail.
  - Consistent “unsupported platform” error across non-supported systems.
  - Clearer fallback behavior on macOS when serial number/UUID are unavailable.

- Documentation
  - License updated to Apache 2.0.

- Chores
  - Improved CI with Go module caching.
  - Ignored macOS .DS_Store files.
  - Updated module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->